### PR TITLE
added analytics

### DIFF
--- a/digital_pet.asm
+++ b/digital_pet.asm
@@ -42,9 +42,16 @@ invalidCommandMsg:       .asciiz "Invalid command - plase try again.\n"
 unrecognisedCmdMsg:      .asciiz "Unknown command - please try again.\n"
 todoMsg: .asciiz "Command recognised - feature not yet implemented.\n"
 
-
-
-
+msg1: .asciiz "\nTotal Time Alive : "
+msg2: .asciiz " seconds"
+msg3: .asciiz "\nFinal Enerygy level: "
+msg4: .asciiz "\nNumbers of commands Entered: "
+msg5: .asciiz "\nNumbers of resets: "
+msg6: .asciiz "Pet died "
+timer: .word 0
+last1: .word 0
+num1: .word 0
+num2: .word 0
 # --- Energy Values ---
 EDR: .word 1
 MEL: .word 15
@@ -117,6 +124,9 @@ skipPrint:
     sw $v0, initial_time 
     la   $a0, gameCommandPrompt
     jal  printString
+    lw $a0,num1
+    addi $a0,$a0,1
+    sw $a0,num1
     la   $a0, buffer   # buffer address
     li   $a1, 20     # max length
     jal  readUserInput
@@ -202,6 +212,10 @@ depleteLoop:
   # print Time +1s... etc
   la $a0, energyDepleteMsg
   jal printString
+  lw $a0,timer
+  addi $a0,$a0,1
+  sw $a0,timer
+
 
   # deplete currentEnergy 
   lw $t3, currentEnergy
@@ -349,6 +363,9 @@ reset:
   addi $sp, $sp, -4
   sw $ra, 0($sp)
   
+  lw $t3,num2
+  addi $t3,$t3,1
+  sw $t3,num2
   # increment resetCount 
   lw $t3, resetCount
   addi $t3, $t3, 1
@@ -388,11 +405,42 @@ reset:
 quit: 
   # TODO:- print stats (feedCount etc.)
 
+
+
   # print quit message
   la $a0, quitMsg
   jal printString
   la $a0, goodbyeMsg
   jal printString
+  
+  la $a0, msg1
+  jal printString
+  lw $a0,timer
+  lw $v0,EDR
+  div $a0,$a0,$v0
+  li $v0,1
+  syscall
+ la $a0, msg2
+  jal printString
+   la $a0, msg3
+  jal printString
+  lw $a0,last1
+  li $v0,1
+  syscall
+  
+     la $a0, msg4
+  jal printString
+  lw $a0,num1
+  li $v0,1
+  syscall
+  
+     la $a0, msg5
+  jal printString
+  lw $a0,num2
+  li $v0,1
+  syscall
+  
+  
   li $v0, 10
   syscall
 
@@ -1123,8 +1171,13 @@ displayEnergyStatus:
     jal  printString
     move $a0, $t0              # restore $a0
 
+
+
     # --- Print current energy value ---
     lw   $a0, currentEnergy
+    ble $a0,0,jump
+    sw $a0,last1
+    jump:
     jal  printInt
     move $a0, $t0
 


### PR DESCRIPTION
new analytics at the end:
total time alive = 
final energy level
number of commands entered
number of resets

timer: .word 0  =total time alive 
last1: .word 0  = stores last energy before deadd
num1:  .word 0  = Counts every command entered
num2:  .word 0  = Counts how many times reset is used

biggest thing is total time alive, calculated by: total time = number of depletion events %EDR
it isnt keeping track of real seconds directly but instead tracks how many times energy depletion happened then % EDR
timer = number of depletion messages printed


